### PR TITLE
修改for循环使用方式上的bug

### DIFF
--- a/avformat/h264.go
+++ b/avformat/h264.go
@@ -90,11 +90,8 @@ func (h264 *H264) Payload(mtu int, payload []byte) (payloads [][]byte) {
 	if videoFrameType == 1 || videoFrameType == 4 {
 		payloads = append(payloads, h264.SPS, h264.PPS)
 	}
-	var nalu []byte
-	var naluLen int
-	for payload := payload[5:]; len(payload) > 4; payload = nalu[naluLen:] {
-		naluLen = int(util.BigEndian.Uint32(payload))
-		nalu = payload[4:]
+	for nalu, naluLen := payload[5:], 4; len(nalu) > naluLen; naluLen = int(util.BigEndian.Uint32(nalu)) + 4 {
+		nalu = nalu[naluLen:]
 		naluType := nalu[0] & 0x1F   //00011111
 		naluRefIdc := nalu[0] & 0x60 //1110000
 


### PR DESCRIPTION
`	var payload = make([]int, 100)
	var (
		nalu    []int
		naluLen int
	)
	for pay := payload[5:]; len(pay) > 4 && len(nalu) >= naluLen; pay = nalu[naluLen:] {
		naluLen += 10
		nalu = pay[4:]
		fmt.Println(len(pay), cap(pay), len(nalu), naluLen)
	}`

像这种使用方式就会出错，提交的这个pr是基于v2.1.8版本做的修改