### PR TITLE
流结束时对AVRing当前节点调用Done()，以便使得等待的订阅能够退出等待。

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -122,6 +122,7 @@ type ChangeStreamCmd struct {
 
 func (r *Stream) onClosed() {
 	Print(Yellow("Stream destoryed :"), BrightCyan(r.StreamPath))
+	r.AVRing.Done()
 	streamCollection.Delete(r.StreamPath)
 	for i, val := range Summary.Streams {
 		if val == &r.StreamInfo {


### PR DESCRIPTION
流结束时订阅者一直处于定等待状态的问题，一般由发布者主动关闭时产生，此时订阅者一般阻塞在Ring.NextR()函数的r.Wait()。由于流主动关闭，此时不会再有新的数据来填充上次调用NextW()移动到的节点，也不会再调用NextW()给当前节点调用Done，于是订阅者会一直等待，并造成相关goroutine的泄漏。如果使主动关闭流来连带关闭发布者，发布者多半会再推1个或多个数据来，一般不会有此问题。
在流结束时对AVRing当前节点调用Done()，可使得等待的订阅结束。对于已经结束的订阅，实际上当前节点已经下移，调用Done()也是安全的。