### PR TITLE
修复 m1 dup2

### DIFF
--- a/util/stderr.go
+++ b/util/stderr.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64 darwin,!arm64
+// +build linux,!arm64,darwin
 
 package util
 

--- a/util/stderr_arm64.go
+++ b/util/stderr_arm64.go
@@ -1,4 +1,4 @@
-// +build linux,arm64 darwin,arm64
+// +build linux,!darwin
 
 package util
 


### PR DESCRIPTION
// Dup2() is not supported in Linux arm64, so we need to change it.
// Dup3() is available in all Linux arches and BSD* variants, but not darwin.

所以默认 Linux和darwin 都用dup2，对于arm64，Linux用dup3即可