### PR TITLE
fix: /api/summary response is too big

### DIFF
--- a/rtp_audio.go
+++ b/rtp_audio.go
@@ -6,7 +6,7 @@ import (
 )
 
 type RTPPublisher struct {
-	rtp.Packet
+	rtp.Packet `json:"-"`
 	lastTs  uint32
 	absTs   uint32
 	lastSeq uint16

--- a/video_track.go
+++ b/video_track.go
@@ -27,7 +27,7 @@ func (vp VideoPack) Copy(ts uint32) VideoPack {
 }
 
 type VideoTrack struct {
-	IDRing *ring.Ring //最近的关键帧位置，首屏渲染
+	IDRing *ring.Ring `json:"-"` //最近的关键帧位置，首屏渲染
 	Track_Base
 	SPSInfo         codec.SPSInfo
 	GOP             int             //关键帧间隔


### PR DESCRIPTION
response of /api/summary contains audio and video ring data which is too large, about 400kB in single sse event, after this patch will be 4kB