### PR TITLE
Githubyonggaofu patch 1

### DIFF
--- a/ring_av.go
+++ b/ring_av.go
@@ -89,3 +89,11 @@ func (r *AVRing) TryRead() (item *AVItem, value interface{}) {
 	}
 	return current, current.Value
 }
+
+// 定位到给定时刻之后的第一个位置
+func (r AVRing) Location(t time.Time) *AVRing {
+	for r.PreItem().canRead && r.PreItem().Timestamp.After(t) {
+		r.Ring = r.Prev()
+	}
+	return &r
+}


### PR DESCRIPTION
在使用monibuca进行二次开发时发现首屏秒开功能只将视频回溯到了关键帧时刻而音频没有回溯，导致订阅者收到的音频和视频不同步，这里通过将音频也回溯到关键帧时刻解决这一问题。由于音频无法chase，因此去除了chase部分