### PR TITLE
配置保存文件写入问题

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -188,7 +188,7 @@ func (opt *Plugin) Save() error {
 		opt.saveTimer = time.AfterFunc(time.Second, func() {
 			lock.Lock()
 			defer lock.Unlock()
-			file, err := os.OpenFile(opt.settingPath(), os.O_CREATE|os.O_WRONLY, 0644)
+			file, err := os.OpenFile(opt.settingPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 			if err == nil {
 				defer file.Close()
 				err = yaml.NewEncoder(file).Encode(opt.Modified)


### PR DESCRIPTION
配置信息保存的时候需要使用os.O_TRUNC 模式, 否则只会覆盖前面的字符，如果之前的配置内容较多 会破坏yaml 文件的结构