### PR TITLE
fix: 添加日志打印行号显示

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -36,7 +36,7 @@ var LogLevel = zap.NewAtomicLevelAt(zap.DebugLevel)
 var Trace bool
 var logger *zap.Logger = zap.New(
 	zapcore.NewCore(zapcore.NewConsoleEncoder(engineConfig), zapcore.AddSync(multipleWriter), LogLevel),
-)
+).WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
 var sugaredLogger *zap.SugaredLogger = logger.Sugar()
 var LocaleLogger *Logger
 


### PR DESCRIPTION
添加日志打印行号显示,解决打印出的行号显示底层log包位置的bug