### PR TITLE
修复在创建流，并且save=2的情况下返回EOF的错误。

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -302,6 +302,9 @@ func (opt *Plugin) Pull(streamPath string, url string, puller IPuller, save int)
 			m[id] = pullConf.PullOnSub[id]
 		}
 		m[streamPath] = url
+		if pullConf.PullOnSub == nil {
+			pullConf.PullOnSub = make(map[string]string)
+		}
 		pullConf.PullOnSub[streamPath] = url
 		opt.RawConfig.ParseModifyFile(map[string]any{
 			"pull": map[string]any{


### PR DESCRIPTION
增加了一个pullConf.PullOnSub判断，如为空则make。